### PR TITLE
Add OJS 3.5 support and a configurable article count

### DIFF
--- a/MostReadBlockPlugin.php
+++ b/MostReadBlockPlugin.php
@@ -1,13 +1,14 @@
 <?php
 
 /**
- * @file plugins/blocks/mostRead/MostReadBlockPlugin.inc.php
+ * @file plugins/blocks/mostRead/MostReadBlockPlugin.php
  *
  * Copyright (c) 2014-2024 Simon Fraser University
  * Copyright (c) 2003-2024 John Willinsky
  * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
  * @class MostReadBlockPlugin
+ *
  * @ingroup plugins_blocks_mostRead
  *
  * @brief Class for "Most Read" block plugin
@@ -16,65 +17,67 @@
 namespace APP\plugins\blocks\mostRead;
 
 use APP\core\Application;
-use APP\core\Services;
-use APP\i18n\AppLocale;
 use APP\facades\Repo;
 use APP\template\TemplateManager;
 use Illuminate\Support\Collection;
-use PKP\cache\CacheManager;
+use Illuminate\Support\Facades\Cache;
 use PKP\core\JSONMessage;
-use PKP\linkAction\LinkAction; 
+use PKP\facades\Locale;
+use PKP\linkAction\LinkAction;
 use PKP\linkAction\request\AjaxModal;
 use PKP\plugins\BlockPlugin;
 use PKP\submission\PKPSubmission;
 
-class MostReadBlockPlugin extends BlockPlugin {
+class MostReadBlockPlugin extends BlockPlugin
+{
+    /** Cache lifetime in seconds (1 day). */
+    private const CACHE_TTL = 60 * 60 * 24;
 
-	/**
-	 * Install default settings on journal creation.
-	 * @return string
-	 */
-	function getContextSpecificPluginSettingsFile() {
-		return $this->getPluginPath() . '/settings.xml';
-	}
+    /**
+     * Install default settings on journal creation.
+     */
+    public function getContextSpecificPluginSettingsFile()
+    {
+        return $this->getPluginPath() . '/settings.xml';
+    }
 
-	/**
-	 * Get the display name of this plugin.
-	 * @return String
-	 */
-	function getDisplayName() {
-		return __('plugins.blocks.mostRead.displayName');
-	}
+    /**
+     * Get the display name of this plugin.
+     */
+    public function getDisplayName()
+    {
+        return __('plugins.blocks.mostRead.displayName');
+    }
 
-	/**
-	 * Get a description of the plugin.
-	 */
-	function getDescription() {
-		return __('plugins.blocks.mostRead.description');
-	}
+    /**
+     * Get a description of the plugin.
+     */
+    public function getDescription()
+    {
+        return __('plugins.blocks.mostRead.description');
+    }
 
-	
-	/**
-	 * @copydoc Plugin::getActions()
-	 */
-	function getActions($request, $actionArgs) {
-		$router = $request->getRouter();
-		import('lib.pkp.classes.linkAction.request.AjaxModal');
-		return array_merge(
-			$this->getEnabled()?array(
-				new LinkAction(
-					'settings',
-					new AjaxModal(
-						$router->url($request, null, null, 'manage', null, array_merge($actionArgs, array('verb' => 'settings'))),
-						$this->getDisplayName()
-					),
-					__('manager.plugins.settings'),
-					null
-				),
-			):array(),
-			parent::getActions($request, $actionArgs)
-		);
-	}
+    /**
+     * @copydoc Plugin::getActions()
+     */
+    public function getActions($request, $actionArgs)
+    {
+        $router = $request->getRouter();
+        return array_merge(
+            $this->getEnabled() ? [
+                new LinkAction(
+                    'settings',
+                    new AjaxModal(
+                        $router->url($request, null, null, 'manage', null, array_merge($actionArgs, ['verb' => 'settings'])),
+                        $this->getDisplayName()
+                    ),
+                    __('manager.plugins.settings'),
+                    null
+                ),
+            ] : [],
+            parent::getActions($request, $actionArgs)
+        );
+    }
 
     /**
      * @copydoc Plugin::manage()
@@ -103,95 +106,99 @@ class MostReadBlockPlugin extends BlockPlugin {
         return parent::manage($args, $request);
     }
 
-	/**
-	 * @copydoc BlockPlugin::getContents
-	 */
-	function getContents($templateMgr, $request = null) 
-	{
-		$context = $request->getContext();
-		if (!$context) return '';
-		
-		$cacheManager = CacheManager::getManager();
-		$cache = $cacheManager->getCache($context->getId(), 'mostread' , array($this, 'getMostReadCache'));
+    /**
+     * @copydoc BlockPlugin::getContents()
+     */
+    public function getContents($templateMgr, $request = null)
+    {
+        $context = $request?->getContext();
+        if (!$context) {
+            return '';
+        }
 
-		$daysToStale = 1;
-		$cachedMetrics = false;
+        $contextId = $context->getId();
 
-		if (time() - $cache->getCacheTime() > 60 * 60 * 24 * $daysToStale) {
-			$cachedMetrics = $cache->getContents();
-			$cache->flush();
-		}
+        $metrics = Cache::remember(
+            $this->getCacheKey($contextId),
+            self::CACHE_TTL,
+            fn () => $this->loadMostRead($contextId)
+        );
 
-		$metrics = $cache->getContents();
+        $locale = Locale::getLocale();
 
-		if (!$metrics && $cachedMetrics) {
-			$metrics = $cachedMetrics;
-			$cache->setEntireCache($cachedMetrics);
-		} elseif (!$metrics) {
-			$cache->flush();
-		}
+        $mostReadBlockTitle = (array) json_decode($this->getSetting($contextId, 'mostReadBlockTitle') ?? '');
+        $blockTitle = $mostReadBlockTitle[$locale] ?? '';
+        $templateMgr->assign('blockTitle', $blockTitle);
 
-		$mostReadBlockTitleSetting = json_decode(
-			$this->getSetting($context->getId(), 'mostReadBlockTitle'),
-			true
-		) ?: null;
+        $mostRead = [];
+        foreach ($metrics as $metric) {
+            $submission = Repo::submission()->get($metric['submissionId']);
+            if (!$submission) {
+                continue;
+            }
+            $publication = $submission->getCurrentPublication();
+            if (!$publication || (int) $publication->getData('status') !== PKPSubmission::STATUS_PUBLISHED) {
+                continue;
+            }
+            $mostRead[] = [
+                'url' => $request->url($context->getPath(), 'article', 'view', [$submission->getBestId()]),
+                'metric' => $metric['metric'],
+                'title' => $publication->getLocalizedFullTitle($locale, 'html'),
+            ];
+        }
 
-		$locale = AppLocale::getLocale();
-		$mostReadBlockTitle = $mostReadBlockTitleSetting[$locale] ?? null;
-		$templateMgr->assign('blockTitle', $mostReadBlockTitle);
+        $templateMgr->assign('mostRead', $mostRead);
+        return parent::getContents($templateMgr, $request);
+    }
 
-		$mostRead = [];
-		foreach($metrics as $metric){
-			$submission = Repo::submission()->get($metric['submissionId']);
-			if(isset($submission) && $submission?->getCurrentPublication()->getData('status') === PKPSubmission::STATUS_PUBLISHED) 
-			{
-				$mostRead[] = [
-					'url' => Application::get()->getRequest()->url($context?->getPath(), 'article', 'view', [$submission->getBestId()]),
-					'metric' => $metric['metric'],
-					'title' => $submission?->getCurrentPublication()->getLocalizedFullTitle($locale, 'html')
-                ];
-			}
-		}
+    /**
+     * Build the cache key for a given context.
+     */
+    public function getCacheKey(int $contextId): string
+    {
+        return "plugins.blocks.mostRead.{$contextId}";
+    }
 
-		$templateMgr->assign('mostRead', $mostRead);
-		return parent::getContents($templateMgr, $request);
-	}
+    /**
+     * Clear the cached metrics for a given context.
+     */
+    public function clearCache(int $contextId): void
+    {
+        Cache::forget($this->getCacheKey($contextId));
+    }
 
-	/**
-	 * Set cache
-	 * @param $cache object
-	 */
-	
-	function getMostReadCache($cache): array 
-	{
-		$mostReadDays = (int) $this->getSetting($cache->context, 'mostReadDays');
-		if (empty($mostReadDays)){
-			$mostReadDays = 7;
-		}
-		$dayString = "-" . $mostReadDays . " days";
+    /**
+     * Query the most read submissions for a context.
+     *
+     * @return array<int, array{submissionId: int, metric: int}>
+     */
+    public function loadMostRead(int $contextId): array
+    {
+        $mostReadDays = (int) $this->getSetting($contextId, 'mostReadDays');
+        if (empty($mostReadDays)) {
+            $mostReadDays = 7;
+        }
+        $dayString = '-' . $mostReadDays . ' days';
 
-        $mostRead = Services::get('publicationStats')->getTotals([
+        $mostReadCount = (int) $this->getSetting($contextId, 'mostReadCount');
+        if ($mostReadCount < 1) {
+            $mostReadCount = 5;
+        }
+
+        $mostRead = app()->get('publicationStats')->getTotals([
             'dateStart' => date('Y-m-d', strtotime($dayString)),
-            'contextIds' => [$cache->context],
-            'count' => 5,
-			'assocTypes' => [Application::ASSOC_TYPE_SUBMISSION_FILE],
+            'contextIds' => [$contextId],
+            'count' => $mostReadCount,
+            'assocTypes' => [Application::ASSOC_TYPE_SUBMISSION_FILE],
         ]);
 
-        $results = (new Collection($mostRead))
-            ->map(function($result) {
-                $submission = Repo::submission()->get($result->submission_id);
-                return [
-                    'submissionId' => $result->submission_id,
-                    'metric' => $result->metric
-                ];
-            })
-            ->filter(function($result) {
-                return $result['submissionId'] && $result['metric'];
-            })
+        return (new Collection($mostRead))
+            ->map(fn ($result) => [
+                'submissionId' => $result->submission_id,
+                'metric' => $result->metric,
+            ])
+            ->filter(fn ($result) => $result['submissionId'] && $result['metric'])
+            ->values()
             ->toArray();
-
-		$cache->setEntireCache($results);
-		return $results;
     }
 }
-?>

--- a/MostReadSettingsForm.php
+++ b/MostReadSettingsForm.php
@@ -1,31 +1,35 @@
 <?php
 
 /**
- * @file plugins/blocks/mostRead/MostReadSettingsForm.inc.php
+ * @file plugins/blocks/mostRead/MostReadSettingsForm.php
  *
  * Copyright (c) 2014-2024 Simon Fraser University
  * Copyright (c) 2003-2024 John Willinsky
  * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
  * @class MostReadSettingsForm
- * @ingroup plugins_generic_mostRead
+ *
+ * @ingroup plugins_blocks_mostRead
  *
  * @brief Form for journal managers to modify Most Read plugin settings
  */
 
- namespace APP\plugins\blocks\mostRead;
+namespace APP\plugins\blocks\mostRead;
 
- use APP\template\TemplateManager;
- use PKP\cache\CacheManager;
- use PKP\form\Form;
+use APP\template\TemplateManager;
+use PKP\form\Form;
+use PKP\form\validation\FormValidator;
+use PKP\form\validation\FormValidatorCSRF;
+use PKP\form\validation\FormValidatorCustom;
+use PKP\form\validation\FormValidatorPost;
 
-class MostReadSettingsForm extends Form {
-
+class MostReadSettingsForm extends Form
+{
     /** @var int */
     public $_contextId;
 
-    /** @var object */
-    public $_plugin;	
+    /** @var MostReadBlockPlugin */
+    public $_plugin;
 
     /**
      * Constructor
@@ -40,10 +44,10 @@ class MostReadSettingsForm extends Form {
 
         parent::__construct($plugin->getTemplateResource('settingsForm.tpl'));
 
-		$this->addCheck(new \PKP\form\validation\FormValidator($this, 'mostReadDays', 'required', 'plugins.blocks.mostRead.settings.mostReadDaysRequired'));
-
-        $this->addCheck(new \PKP\form\validation\FormValidatorPost($this));
-        $this->addCheck(new \PKP\form\validation\FormValidatorCSRF($this));
+        $this->addCheck(new FormValidator($this, 'mostReadDays', 'required', 'plugins.blocks.mostRead.settings.mostReadDaysRequired'));
+        $this->addCheck(new FormValidatorCustom($this, 'mostReadCount', 'optional', 'plugins.blocks.mostRead.settings.mostReadCountInvalid', fn ($value) => ctype_digit((string) $value) && (int) $value >= 1));
+        $this->addCheck(new FormValidatorPost($this));
+        $this->addCheck(new FormValidatorCSRF($this));
     }
 
     /**
@@ -51,10 +55,11 @@ class MostReadSettingsForm extends Form {
      */
     public function initData()
     {
-		$mostReadBlockTitle = (array) json_decode($this->_plugin->getSetting($this->_contextId, 'mostReadBlockTitle'));
+        $mostReadBlockTitle = (array) json_decode($this->_plugin->getSetting($this->_contextId, 'mostReadBlockTitle') ?? '');
         $this->_data = [
             'mostReadDays' => $this->_plugin->getSetting($this->_contextId, 'mostReadDays'),
-			'mostReadBlockTitle' => $mostReadBlockTitle,
+            'mostReadCount' => $this->_plugin->getSetting($this->_contextId, 'mostReadCount'),
+            'mostReadBlockTitle' => $mostReadBlockTitle,
         ];
     }
 
@@ -63,8 +68,8 @@ class MostReadSettingsForm extends Form {
      */
     public function readInputData()
     {
-		$this->readUserVars(array('mostReadDays', 'mostReadBlockTitle'));
-    }	
+        $this->readUserVars(['mostReadDays', 'mostReadCount', 'mostReadBlockTitle']);
+    }
 
     /**
      * @copydoc Form::fetch()
@@ -83,18 +88,14 @@ class MostReadSettingsForm extends Form {
      */
     public function execute(...$functionArgs)
     {
-		$mostReadBlockTitle = json_encode($this->getData('mostReadBlockTitle'));
+        $mostReadBlockTitle = json_encode($this->getData('mostReadBlockTitle'));
         $this->_plugin->updateSetting($this->_contextId, 'mostReadDays', $this->getData('mostReadDays'), 'string');
-		$this->_plugin->updateSetting($this->_contextId, 'mostReadBlockTitle', $mostReadBlockTitle, 'string');
-        
-		# empty current cache
-		$cacheManager = CacheManager::getManager();
-		$cache = $cacheManager->getCache('mostread', $this->_contextId, array($this->_plugin, 'getMostReadCache'));
-		$cache->flush();		
-		parent::execute(...$functionArgs);
-    }
-}
+        $this->_plugin->updateSetting($this->_contextId, 'mostReadCount', $this->getData('mostReadCount'), 'string');
+        $this->_plugin->updateSetting($this->_contextId, 'mostReadBlockTitle', $mostReadBlockTitle, 'string');
 
-if (!PKP_STRICT_MODE) {
-    class_alias('\APP\plugins\blocks\mostRead\MostReadSettingsForm', '\MostReadSettingsForm');
+        // Empty the current cache so new settings take effect immediately
+        $this->_plugin->clearCache($this->_contextId);
+
+        return parent::execute(...$functionArgs);
+    }
 }

--- a/locale/en/locale.po
+++ b/locale/en/locale.po
@@ -31,3 +31,12 @@ msgstr "Block title"
 
 msgid "plugins.blocks.mostRead.settings.saved"
 msgstr "Most Read Block plugin settings saved"
+
+msgid "plugins.blocks.mostRead.settings.mostReadDaysRequired"
+msgstr "Please enter the number of days to consider."
+
+msgid "plugins.blocks.mostRead.settings.count"
+msgstr "Number of articles"
+
+msgid "plugins.blocks.mostRead.settings.mostReadCountInvalid"
+msgstr "Please enter a whole number greater than or equal to 1."

--- a/locale/pt_BR/locale.po
+++ b/locale/pt_BR/locale.po
@@ -31,3 +31,12 @@ msgstr "Título do bloco"
 
 msgid "plugins.blocks.mostRead.settings.saved"
 msgstr "Configurações do plug-in do bloco de artigos mais lido"
+
+msgid "plugins.blocks.mostRead.settings.mostReadDaysRequired"
+msgstr "Informe a quantidade de dias a considerar."
+
+msgid "plugins.blocks.mostRead.settings.count"
+msgstr "Quantidade de artigos"
+
+msgid "plugins.blocks.mostRead.settings.mostReadCountInvalid"
+msgstr "Informe um número inteiro maior ou igual a 1."

--- a/templates/block.tpl
+++ b/templates/block.tpl
@@ -1,5 +1,5 @@
 {**
- * plugins/blocks/mostRead/block.tpl
+ * plugins/blocks/mostRead/templates/block.tpl
  *
  * Copyright (c) 2014-2024 Simon Fraser University
  * Copyright (c) 2003-2024 John Willinsky
@@ -7,16 +7,18 @@
  *
  * "Most Read" block.
  *}
-<div class="pkp_block block_developed_by">
+{if !empty($mostRead)}
+<div class="pkp_block block_most_read">
 	<div class="content">
-		{if isset($blockTitle) }<span class="title">{$blockTitle}</span>{/if}
-			<ul class="most_read">
+		{if !empty($blockTitle)}<span class="title">{$blockTitle|escape}</span>{/if}
+		<ul class="most_read">
 			{foreach from=$mostRead item=submission}
 				<li class="most_read_article">
-					<div class="most_read_article_title"><a href="{$submission.url}">{$submission.title}</a></div>
-					<div class="most_read_article_journal"><span class="fa fa-eye"></span> {$submission.metric}</div>
+					<div class="most_read_article_title"><a href="{$submission.url|escape}">{$submission.title}</a></div>
+					<div class="most_read_article_journal"><span class="fa fa-eye"></span> {$submission.metric|escape}</div>
 				</li>
 			{/foreach}
-			</ul>
+		</ul>
 	</div>
 </div>
+{/if}

--- a/templates/settingsForm.tpl
+++ b/templates/settingsForm.tpl
@@ -26,6 +26,10 @@
 			{fbvElement type="text" label="plugins.blocks.mostRead.settings.days" id="mostReadDays" value=$mostReadDays}
 		{/fbvFormSection}
 
+		{fbvFormSection for="mostReadCount"}
+			{fbvElement type="text" label="plugins.blocks.mostRead.settings.count" id="mostReadCount" value=$mostReadCount}
+		{/fbvFormSection}
+
 		{fbvFormSection for="mostReadBlockTitle"}
 			{fbvElement type="text" label="plugins.blocks.mostRead.settings.blockTitle" id="mostReadBlockTitle" value=$mostReadBlockTitle multilingual=true}
 		{/fbvFormSection}		

--- a/version.xml
+++ b/version.xml
@@ -13,8 +13,8 @@
 <version>
 	<application>mostRead</application>
 	<type>plugins.blocks</type>
-	<release>3.4.0.1</release>
-	<date>2024-07-26</date>
+	<release>3.5.0.1</release>
+	<date>2026-07-02</date>
 	<lazy-load>1</lazy-load>
 	<class>MostReadBlockPlugin</class>
 </version>


### PR DESCRIPTION
## What this adds

This PR brings the **Most Read** block plugin to **OJS 3.5**, plus a small feature.

### 1. OJS 3.5 compatibility
- Replace `PKP\cache\CacheManager` with the `Illuminate\Support\Facades\Cache` facade.
- Replace `APP\i18n\AppLocale` / `APP\core\Services` usage with the `PKP\facades\Locale`
  facade and `Repo`.
- Adjust namespaced imports accordingly.

These calls target 3.5 APIs, so the branch is meant for the **3.5.x** line (it will not run
on 3.4). See the note on branching below.

### 2. Configurable number of articles
A new **"Number of articles"** (`mostReadCount`) setting lets journal managers choose how
many items the block shows, with validation (whole number ≥ 1). Existing behavior is
preserved when the field is left empty.

### 3. Template hardening
- Escape output (`|escape`) and only render the block when there are results
  (`{if !empty($mostRead)}`).
- Rename the block CSS class from `block_developed_by` to `block_most_read`.

### 4. Housekeeping
- PSR-12 formatting on the two PHP classes.
- New locale keys (`settings.count`, `settings.mostReadCountInvalid`,
  `settings.mostReadDaysRequired`) added to `en` and `pt_BR`.
- `version.xml` bumped to `3.5.0.1` (copyright header unchanged).

## A note on branching

The changes require 3.5 and would break 3.4 if merged straight into a 3.4 `master`.
If you'd prefer, I'm happy to **retarget this to a `stable-3_5_0` branch** (or rebase it
however you cut new OJS lines) — just let me know.

## Context / credit

These changes come from work done at **[OJSBR](https://ojsbr.com.br)** while adapting the
plugin for OJS 3.5 deployments. Thanks for maintaining Most Read — it's widely used in the
Brazilian OJS community. Happy to iterate on anything here.
